### PR TITLE
sched_policy: zero proc_name buffer before populating

### DIFF
--- a/libcutils/sched_policy.c
+++ b/libcutils/sched_policy.c
@@ -138,6 +138,7 @@ static void __initialize(void) {
     sprintf(proc_name, "/proc/%d/cmdline", ptid);
 
     pfd = open(proc_name, O_RDONLY);
+    memset(proc_name, 0, sizeof(proc_name));
     if (pfd > 0) {
         read(pfd, proc_name, sizeof(proc_name) - 1);
         close(pfd);


### PR DESCRIPTION
The process name will be read into the buffer containing
the proc name filepath.  We need to reinitialize the buffer
before reading into it.

Change-Id: I67710819c895d3f9e2b0d486ab8a11f29f8318e8